### PR TITLE
remove other md5sums from .md5 file

### DIFF
--- a/src/functions-common.sh
+++ b/src/functions-common.sh
@@ -58,6 +58,7 @@ function download_md5 {
     then
         wget --output-file=$BUILD_HOME/work/build.log -O download/$FILENAME.md5 $DIR_URL/MD5SUM || STATUS=$?
         sed -i "s/$FILENAME/download\/$FILENAME/g" download/$FILENAME.md5
+        sed -i "/$FILENAME/!d" download/$FILENAME.md5
     else
         wget --output-file=$BUILD_HOME/work/build.log -O download/$FILENAME.md5 $DIR_URL/$FILENAME.md5 || STATUS=$?
         echo "  download/$FILENAME" >> download/$FILENAME.md5 


### PR DESCRIPTION
the build script was failing  on  ubuntu 16.04:

> ╰─➤  ./build-eap6.sh 6.2.0                   
> Here we go. Building EAP version 6.2.0.
> Trying to download jboss-eap-6.2.0-src.zip.
> download/jboss-eap-6.2.0-src.zip: OK
> md5sum: jboss-eap-native-6.2.0-hpux3.src.zip: No such file or directory
> jboss-eap-native-6.2.0-hpux3.src.zip: FAILED open or read
> md5sum: jboss-eap-native-6.2.0-RHEL-src.zip: No such file or directory
> jboss-eap-native-6.2.0-RHEL-src.zip: FAILED open or read
> md5sum: jboss-eap-native-6.2.0-sun10.src.zip: No such file or directory
> jboss-eap-native-6.2.0-sun10.src.zip: FAILED open or read
> md5sum: jboss-eap-native-6.2.0-win6.src.zip: No such file or directory
> jboss-eap-native-6.2.0-win6.src.zip: FAILED open or read
> md5sum: WARNING: 4 listed files could not be read
> ==== FAIL ====
> Checksum verification failed for jboss-eap-6.2.0-src.zip


http://ftp.redhat.com/redhat/jbeap/6.2.0/en/source/MD5SUM contains other md5sums than just jboss-eap-6.2.0-src.zip . This change removes not needed md5sums from jboss-eap-6.2.0-src.zip.md5``