### PR TITLE
also remove 'wildfly-core-model-test-framework' on 7.0.9 build

### DIFF
--- a/src/jboss-eap-7.properties
+++ b/src/jboss-eap-7.properties
@@ -34,6 +34,13 @@ versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1
 7.0.9.modules=org.apache.commons.logging
 
 # Delete XML elements
+7.0.9.xpath.delete.core=pom.xml,//_:dependency[_:artifactId='wildfly-core-model-test-framework']
+7.0.9.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
+7.0.9.xpath.delete.eap=dist/pom.xml,//_:dependency[_:artifactId='jboss-server-migration-eap7.1-feature-pack']
+7.0.9.xpath.delete.eap=dist/server-provisioning.xml,//_:feature-pack[@artifactId='jboss-server-migration-eap7.1-feature-pack']
+7.0.9.xpath.delete.eap=build/pom.xml,//_:dependency[_:artifactId='jboss-server-migration-eap7.1-feature-pack']
+7.0.9.xpath.delete.eap=build/server-provisioning.xml,//_:feature-pack[@artifactId='jboss-server-migration-eap7.1-feature-pack']
+#
 7.1.0.xpath.delete.core=pom.xml,//_:dependency[_:artifactId='wildfly-core-model-test-framework']
 7.1.0.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
 7.1.0.xpath.delete.eap=dist/pom.xml,//_:dependency[_:artifactId='jboss-server-migration-eap7.1-feature-pack']


### PR DESCRIPTION
Hi, I have problem building 7.0.9, due to the dependency `wildfly-core-model-test-framework`.
I've check it is not published to neither GA nor Early Access repository, so I modify the setting file to also remove `wildfly-core-model-test-framework`, same as 7.1.x. After modification the script work flawlessly on Debian 9 🎉.

Btw, thank you so much for this project. We have client running 7.0.9 in production and getting a 7.0.9 EAP install was a major PITA for us.