### PR TITLE
Patch releases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ If you don't want to use git, download the archive, unzip it and run the main sc
 
 Versions
 --------
-The build-eap7.sh script supports 7.0.0->7.0.9, 7.1.0->7.1.4, 7.2.0->7.2.7, 7.3.0->7.3.9, 7.4.0->7.4.3.
+The build-eap7.sh script supports 7.0.0->7.0.9, 7.1.0->7.1.4, 7.2.0->7.2.9, 7.3.0->7.3.10, 7.4.0->7.4.3.
 
 The build-eap6.sh script supports 6.1.1, 6.2.0->6.2.4, 6.3.0->6.3.3, 6.4.0->6.4.23.
 

--- a/src/functions-7.sh
+++ b/src/functions-7.sh
@@ -50,7 +50,7 @@ function prepare_core_source {
 
         cd $BUILD_HOME/work/wildfly-core-$CORE_VERSION/core-feature-pack
     else
-        MAVEN_REPO=https://maven.repository.redhat.com/earlyaccess
+        MAVEN_REPO=https://maven.repository.redhat.com/ga
         if [[ $CORE_FULL_SOURCE_VERSION = *"-redhat-"* ]]
         then
             download_and_unzip $MAVEN_REPO/org/wildfly/core/wildfly-core-parent/$CORE_FULL_SOURCE_VERSION/wildfly-core-parent-$CORE_FULL_SOURCE_VERSION-project-sources.tar.gz

--- a/src/jboss-eap-7.properties
+++ b/src/jboss-eap-7.properties
@@ -1,4 +1,4 @@
-versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1,7.1.2,7.1.3,7.1.4,7.2.0,7.2.1,7.2.2,7.2.3,7.2.4,7.2.5,7.2.6,7.2.7,7.3.0,7.3.1,7.3.2,7.3.3,7.3.4,7.3.5,7.3.6,7.3.7,7.3.8,7.3.9,7.4.0,7.4.1,7.4.2,7.4.3
+versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1,7.1.2,7.1.3,7.1.4,7.2.0,7.2.1,7.2.2,7.2.3,7.2.4,7.2.5,7.2.6,7.2.7,7.2.8,7.2.9,7.3.0,7.3.1,7.3.2,7.3.3,7.3.4,7.3.5,7.3.6,7.3.7,7.3.8,7.3.9,7.3.10,7.4.0,7.4.1,7.4.2,7.4.3
 
 # core version and corresponding version with full source code
 # EAP 7.0.0
@@ -50,6 +50,11 @@ versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1
 6.0.21.Final-redhat-00001=6.0.2.Final
 # EAP 7.2.7
 6.0.24.Final-redhat-00001=6.0.2.Final
+# EAP 7.2.8
+6.0.27.Final-redhat-00001=6.0.2.Final
+# EAP 7.2.9
+6.0.30.Final-redhat-00001=6.0.2.Final
+
 # EAP 7.3.0 : direct download of the core source file
 # EAP 7.3.1
 10.1.7.Final-redhat-00001=10.0.3.Final
@@ -68,6 +73,8 @@ versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1
 # EAP 7.3.8
 10.1.21.Final-redhat-00001=10.0.3.Final
 # EAP 7.3.9 : direct download of the core source file
+# EAP 7.3.10 : direct download of the core source file
+
 # EAP 7.4.0 : direct download of the core source file
 # EAP 7.4.1 : direct download of the core source file
 # EAP 7.4.2 : direct download of the core source file
@@ -126,6 +133,12 @@ versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1
 7.2.5.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
 7.2.6.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
 7.2.7.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
+7.2.8.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
+7.2.8.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="org.jboss.msc"
+7.2.8.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
+7.2.9.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
+7.2.9.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="org.jboss.msc"
+7.2.9.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
 # 
 7.3.0.xpath.delete.core=pom.xml,//_:dependency[_:artifactId='wildfly-core-model-test-framework']
 7.3.1.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
@@ -154,6 +167,8 @@ versions=7.0.0,7.0.1,7.0.2,7.0.3,7.0.4,7.0.5,7.0.6,7.0.7,7.0.8,7.0.9,7.1.0,7.1.1
 7.3.8.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
 7.3.9.xpath.delete.core=feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
 7.3.9.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
+7.3.10.xpath.insert.core=src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
+#
 7.4.0.xpath.delete.core=legacy-feature-pack/feature-pack-build.xml,//_:copy-artifact[@artifact='org.wildfly.openssl:wildfly-openssl-macosx-x86_64']
 7.4.0.xpath.insert.core=common/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml,/_:module/_:dependencies/_:module[position()=1],module,name="java.desktop"
 7.4.1.xpath.delete.eap=dist-legacy/pom.xml,//_:dependency[_:artifactId='wildfly-testsuite-shared']


### PR DESCRIPTION
Updated maven repo from https://maven.repository.redhat.com/earlyaccess to https://maven.repository.redhat.com/ga
Inserted dependencies for org.jboss.msc and java.desktop to module domain-http-interface

Builds and starts up properly, my application also runs correctly, but I have to admit that I'm probably not aware of the full impact of those changes.

Thanks @cher1705 for the suggestions.